### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/102/553/765/102553765.geojson
+++ b/data/102/553/765/102553765.geojson
@@ -140,6 +140,9 @@
         "wd:id":"Q723325"
     },
     "wof:country":"SX",
+    "wof:geom_alt":[
+        "woedb"
+    ],
     "wof:geomhash":"f7ad0f0aee9c9367789b205b18425a64",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
         }
     ],
     "wof:id":102553765,
-    "wof:lastmodified":1566651191,
+    "wof:lastmodified":1582344585,
     "wof:name":"Prinses Juliana International Airport",
     "wof:parent_id":-1,
     "wof:placetype":"campus",

--- a/data/856/321/85/85632185.geojson
+++ b/data/856/321/85/85632185.geojson
@@ -502,6 +502,10 @@
     },
     "wof:country":"SX",
     "wof:country_alpha3":"SXM",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"e6f0f4d1160bdf219c8dd7336c2242b5",
     "wof:hierarchy":[
         {
@@ -518,7 +522,7 @@
         "eng",
         "nld"
     ],
-    "wof:lastmodified":1566651192,
+    "wof:lastmodified":1582344585,
     "wof:name":"Sint Maarten",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/782/29/85678229.geojson
+++ b/data/856/782/29/85678229.geojson
@@ -435,6 +435,9 @@
         "hasc:id":"SX.SM"
     },
     "wof:country":"SX",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"db863ab51065b2ef3deab356b1fedf14",
     "wof:hierarchy":[
         {
@@ -452,7 +455,7 @@
         "eng",
         "nld"
     ],
-    "wof:lastmodified":1566651192,
+    "wof:lastmodified":1582344585,
     "wof:name":"Sint Maarten",
     "wof:parent_id":85632185,
     "wof:placetype":"region",

--- a/data/890/434/823/890434823.geojson
+++ b/data/890/434/823/890434823.geojson
@@ -206,6 +206,9 @@
     },
     "wof:country":"SX",
     "wof:created":1469052041,
+    "wof:geom_alt":[
+        "unknown"
+    ],
     "wof:geomhash":"7773885db8cd1aaa95ef136283937f4c",
     "wof:hierarchy":[
         {
@@ -216,7 +219,7 @@
         }
     ],
     "wof:id":890434823,
-    "wof:lastmodified":1566651198,
+    "wof:lastmodified":1582344585,
     "wof:name":"Philipsburg",
     "wof:parent_id":85678229,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.