### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/102/553/765/102553765.geojson
+++ b/data/102/553/765/102553765.geojson
@@ -19,11 +19,20 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":13.0,
+    "name:afr_x_preferred":[
+        "Prinses Juliana Internasionale Lughawe"
+    ],
     "name:ara_x_preferred":[
         "\u0645\u0637\u0627\u0631 \u0627\u0644\u0623\u0645\u064a\u0631\u0629 \u062c\u0648\u0644\u064a\u0627\u0646\u0627 \u0627\u0644\u062f\u0648\u0644\u064a"
     ],
     "name:ast_x_preferred":[
         "Aeropuertu Internacional Princesa Juliana"
+    ],
+    "name:ben_x_preferred":[
+        "\u09b0\u09be\u099c\u0995\u09c1\u09ae\u09be\u09b0\u09c0 \u099c\u09c1\u09b2\u09bf\u09af\u09bc\u09be\u09a8\u09be \u0986\u09a8\u09cd\u09a4\u09b0\u09cd\u099c\u09be\u09a4\u09bf\u0995 \u09ac\u09bf\u09ae\u09be\u09a8\u09ac\u09a8\u09cd\u09a6\u09b0"
+    ],
+    "name:cat_x_preferred":[
+        "Aeroport Internacional Princesa Juliana"
     ],
     "name:ces_x_preferred":[
         "Mezin\u00e1rodn\u00ed leti\u0161t\u011b princezny Juliany"
@@ -53,6 +62,9 @@
     "name:fra_x_preferred":[
         "a\u00e9roport international Princess Juliana"
     ],
+    "name:fra_x_variant":[
+        "a\u00e9roport international Princesse-Juliana"
+    ],
     "name:heb_x_preferred":[
         "\u05e0\u05de\u05dc \u05d4\u05ea\u05e2\u05d5\u05e4\u05d4 \u05d4\u05e0\u05e1\u05d9\u05db\u05d4 \u05d9\u05d5\u05dc\u05d9\u05d0\u05e0\u05d4"
     ],
@@ -79,6 +91,9 @@
     ],
     "name:lit_x_preferred":[
         "Princes\u0117s Julianos tarptautinis oro uostas"
+    ],
+    "name:mkd_x_preferred":[
+        "\u041c\u0435\u0453\u0443\u043d\u0430\u0440\u043e\u0434\u0435\u043d \u0430\u0435\u0440\u043e\u0434\u0440\u043e\u043c \u201e\u041f\u0440\u0438\u043d\u0446\u0435\u0437\u0430 \u0408\u0443\u043b\u0438\u0458\u0430\u043d\u0430\u201c"
     ],
     "name:msa_x_preferred":[
         "Lapangan Terbang Antarabangsa Princess Juliana"
@@ -115,6 +130,9 @@
     ],
     "name:ukr_x_preferred":[
         "\u0410\u0435\u0440\u043e\u043f\u043e\u0440\u0442 \u041f\u0440\u0438\u043d\u0446\u0435\u0441\u0438 \u042e\u043b\u0456\u0430\u043d\u0438"
+    ],
+    "name:uzb_x_preferred":[
+        "Malika Juliana Xalqaro Aeroporti"
     ],
     "name:vie_x_preferred":[
         "S\u00e2n bay qu\u1ed1c t\u1ebf Princess Juliana"
@@ -159,7 +177,7 @@
         }
     ],
     "wof:id":102553765,
-    "wof:lastmodified":1631749874,
+    "wof:lastmodified":1690867109,
     "wof:name":"Prinses Juliana International Airport",
     "wof:parent_id":-1,
     "wof:placetype":"campus",

--- a/data/421/186/603/421186603.geojson
+++ b/data/421/186/603/421186603.geojson
@@ -26,6 +26,9 @@
     "name:als_x_preferred":[
         "Diamant"
     ],
+    "name:anp_x_preferred":[
+        "\u0939\u0940\u0930\u093e"
+    ],
     "name:ara_x_preferred":[
         "\u0623\u0644\u0645\u0627\u0633"
     ],
@@ -40,6 +43,12 @@
     ],
     "name:ast_x_preferred":[
         "Diamante"
+    ],
+    "name:ast_x_variant":[
+        "diamante"
+    ],
+    "name:azb_x_preferred":[
+        "\u0622\u0644\u0645\u0627\u0633"
     ],
     "name:aze_x_preferred":[
         "Almaz"
@@ -89,8 +98,14 @@
     "name:ckb_x_preferred":[
         "\u0626\u06d5\u06b5\u0645\u0627\u0633"
     ],
+    "name:cor_x_preferred":[
+        "adamant"
+    ],
     "name:crh_x_preferred":[
         "Elmaz"
+    ],
+    "name:crh_x_variant":[
+        "elmaz"
     ],
     "name:csb_x_preferred":[
         "Diama\u0144t"
@@ -103,6 +118,9 @@
     ],
     "name:dan_x_preferred":[
         "Diamant"
+    ],
+    "name:dan_x_variant":[
+        "diamant"
     ],
     "name:deu_x_preferred":[
         "Diamant"
@@ -124,6 +142,9 @@
     ],
     "name:est_x_preferred":[
         "Teemant"
+    ],
+    "name:est_x_variant":[
+        "teemant"
     ],
     "name:eus_x_preferred":[
         "Diamante"
@@ -154,6 +175,9 @@
     ],
     "name:glg_x_preferred":[
         "Diamante"
+    ],
+    "name:gom_x_preferred":[
+        "\u0939\u093f\u0930\u094b"
     ],
     "name:gsw_x_preferred":[
         "Diamant"
@@ -233,11 +257,17 @@
     "name:kor_x_preferred":[
         "\ub2e4\uc774\uc544\ubaac\ub4dc"
     ],
+    "name:kur_x_preferred":[
+        "elmas"
+    ],
     "name:lat_x_preferred":[
         "Adamas"
     ],
     "name:lav_x_preferred":[
         "Dimants"
+    ],
+    "name:lav_x_variant":[
+        "dimants"
     ],
     "name:lim_x_preferred":[
         "Diamaant"
@@ -248,6 +278,9 @@
     "name:lmo_x_preferred":[
         "Diamant"
     ],
+    "name:lzh_x_preferred":[
+        "\u91d1\u525b\u77f3"
+    ],
     "name:mal_x_preferred":[
         "\u0d35\u0d1c\u0d4d\u0d30\u0d02"
     ],
@@ -257,11 +290,17 @@
     "name:mhr_x_preferred":[
         "\u0410\u043b\u043c\u0430\u0437"
     ],
+    "name:mhr_x_variant":[
+        "\u0430\u043b\u043c\u0430\u0437"
+    ],
     "name:mkd_x_preferred":[
         "\u0414\u0438\u0458\u0430\u043c\u0430\u043d\u0442"
     ],
     "name:mkd_x_variant":[
         "\u0434\u0438\u0458\u0430\u043c\u0430\u043d\u0442"
+    ],
+    "name:mlg_x_preferred":[
+        "Diamondra"
     ],
     "name:mon_x_preferred":[
         "\u0410\u043b\u043c\u0430\u0430\u0437"
@@ -280,6 +319,9 @@
     ],
     "name:nan_x_preferred":[
         "So\u0101n-chio\u030dh"
+    ],
+    "name:nds_x_preferred":[
+        "Demant"
     ],
     "name:nep_x_preferred":[
         "\u0939\u093f\u0930\u093e"
@@ -311,11 +353,17 @@
     "name:ori_x_preferred":[
         "\u0b39\u0b40\u0b30\u0b3e"
     ],
+    "name:orm_x_preferred":[
+        "Moogaa(Diamond)"
+    ],
     "name:pan_x_preferred":[
         "\u0a39\u0a40\u0a30\u0a3e"
     ],
     "name:pnb_x_preferred":[
         "\u06be\u06cc\u0631\u0627"
+    ],
+    "name:pnb_x_variant":[
+        "\u06c1\u06cc\u0631\u0627"
     ],
     "name:pol_x_preferred":[
         "Diament"
@@ -362,11 +410,17 @@
     "name:scn_x_preferred":[
         "Diamanti"
     ],
+    "name:scn_x_variant":[
+        "diamanti"
+    ],
     "name:sco_x_preferred":[
         "Diamond"
     ],
     "name:sco_x_variant":[
         "diamond"
+    ],
+    "name:sgs_x_preferred":[
+        "Deimants"
     ],
     "name:sin_x_preferred":[
         "\u0daf\u0dd2\u0dba\u0db8\u0db1\u0dca\u0dad\u0dd2"
@@ -377,8 +431,26 @@
     "name:slv_x_preferred":[
         "Diamant"
     ],
+    "name:slv_x_variant":[
+        "diamant"
+    ],
+    "name:sme_x_preferred":[
+        "diam\u00e1nta"
+    ],
+    "name:smn_x_preferred":[
+        "tiimaant"
+    ],
+    "name:sms_x_preferred":[
+        "timantt"
+    ],
+    "name:sna_x_preferred":[
+        "Ngoda"
+    ],
     "name:snd_x_preferred":[
         "\u0627\u0644\u0645\u0627\u0633"
+    ],
+    "name:snd_x_variant":[
+        "\u0647\u064a\u0631\u0648"
     ],
     "name:som_x_preferred":[
         "Luul"
@@ -427,6 +499,9 @@
     ],
     "name:tha_x_preferred":[
         "\u0e40\u0e1e\u0e0a\u0e23"
+    ],
+    "name:trv_x_preferred":[
+        "Uyug"
     ],
     "name:tur_x_preferred":[
         "Elmas"
@@ -531,7 +606,7 @@
         }
     ],
     "wof:id":421186603,
-    "wof:lastmodified":1566651197,
+    "wof:lastmodified":1690867110,
     "wof:name":"Diamond",
     "wof:parent_id":85678229,
     "wof:placetype":"locality",

--- a/data/421/190/749/421190749.geojson
+++ b/data/421/190/749/421190749.geojson
@@ -32,6 +32,9 @@
     "name:hye_x_preferred":[
         "\u053c\u0578\u0578\u0582\u0580 \u054a\u0580\u056b\u0576\u057d\u0565\u057d \u0554\u0578\u0582\u0561\u0569\u0580"
     ],
+    "name:ita_x_preferred":[
+        "Lower Prince's Quarter"
+    ],
     "name:nld_x_preferred":[
         "Lower Prince's Quarter"
     ],
@@ -47,11 +50,17 @@
     "name:rus_x_preferred":[
         "\u041b\u043e\u0443\u044d\u0440-\u041f\u0440\u0438\u043d\u0441-\u041a\u0443\u043e\u0442\u0435\u0440"
     ],
+    "name:spa_x_preferred":[
+        "Lower Prince"
+    ],
     "name:urd_x_preferred":[
         "\u0644\u0648\u0626\u0631 \u067e\u0631\u0646\u0633 \u06a9\u0648\u0627\u0631\u0679\u0631"
     ],
     "name:zho_x_preferred":[
         "\u4e0b\u592a\u5b50\u5340"
+    ],
+    "name:zho_x_variant":[
+        "\u4e0b\u592a\u5b50\u533a"
     ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":421190749,
-    "wof:lastmodified":1566651197,
+    "wof:lastmodified":1690867110,
     "wof:name":"Lower Prince's Quarter",
     "wof:parent_id":85678229,
     "wof:placetype":"locality",

--- a/data/421/191/719/421191719.geojson
+++ b/data/421/191/719/421191719.geojson
@@ -23,6 +23,9 @@
     "name:bel_x_preferred":[
         "\u041f\u0440\u0430\u0432\u0430\u0441\u0443\u0434\u0434\u0437\u0435"
     ],
+    "name:bel_x_variant":[
+        "\u0441\u0443\u0434\u043e\u0432\u044b \u043f\u0440\u0430\u0446\u044d\u0441"
+    ],
     "name:bul_x_preferred":[
         "\u041f\u0440\u0430\u0432\u043e\u0441\u044a\u0434\u0438\u0435"
     ],
@@ -44,6 +47,9 @@
     "name:deu_x_preferred":[
         "Gerichtsverhandlung"
     ],
+    "name:dsb_x_preferred":[
+        "sudniske jadnanje"
+    ],
     "name:ell_x_preferred":[
         "\u03b4\u03af\u03ba\u03b7"
     ],
@@ -52,6 +58,9 @@
     ],
     "name:epo_x_preferred":[
         "proceso"
+    ],
+    "name:est_x_preferred":[
+        "Kohtuprotsess"
     ],
     "name:eus_x_preferred":[
         "Epaiketa"
@@ -62,17 +71,35 @@
     "name:fin_x_preferred":[
         "Oikeudenk\u00e4ynti"
     ],
+    "name:fin_x_variant":[
+        "oikeudenk\u00e4ynti"
+    ],
     "name:fra_x_preferred":[
         "Proc\u00e8s"
     ],
     "name:fra_x_variant":[
         "affaire judiciaire"
     ],
+    "name:gle_x_preferred":[
+        "triail"
+    ],
+    "name:grc_x_preferred":[
+        "\u03b4\u1fd0\u0301\u03ba\u03b7"
+    ],
+    "name:hau_x_preferred":[
+        "shari'a"
+    ],
     "name:heb_x_preferred":[
         "\u05de\u05e9\u05e4\u05d8"
     ],
+    "name:hin_x_preferred":[
+        "\u0935\u093f\u091a\u093e\u0930\u0923"
+    ],
     "name:hun_x_preferred":[
         "per"
+    ],
+    "name:hun_x_variant":[
+        "t\u00e1rgyal\u00e1s"
     ],
     "name:hye_x_preferred":[
         "\u0531\u0580\u0564\u0561\u0580\u0561\u0564\u0561\u057f\u0578\u0582\u0569\u0575\u0578\u0582\u0576"
@@ -89,6 +116,9 @@
     "name:jpn_x_preferred":[
         "\u30c8\u30e9\u30a4\u30a2\u30eb"
     ],
+    "name:kan_x_preferred":[
+        "\u0cb5\u0cbf\u0c9a\u0cbe\u0cb0\u0ca3\u0cc6"
+    ],
     "name:kbp_x_preferred":[
         "T\u0254m k\u0269h\u028ah\u028at\u028a"
     ],
@@ -101,11 +131,17 @@
     "name:lit_x_variant":[
         "teismo pos\u0117dis"
     ],
+    "name:mal_x_preferred":[
+        "\u0d35\u0d3f\u0d1a\u0d3e\u0d30\u0d23"
+    ],
     "name:mkd_x_preferred":[
         "\u0421\u0443\u0434\u0435\u045a\u0435"
     ],
     "name:mkd_x_variant":[
         "\u0441\u0443\u0434\u0435\u045a\u0435"
+    ],
+    "name:msa_x_preferred":[
+        "perbicaraan"
     ],
     "name:nld_x_preferred":[
         "Rechtszitting"
@@ -128,11 +164,20 @@
     "name:por_x_preferred":[
         "Processo"
     ],
+    "name:por_x_variant":[
+        "processo"
+    ],
     "name:rus_x_preferred":[
         "\u0441\u0443\u0434\u0435\u0431\u043d\u044b\u0439 \u043f\u0440\u043e\u0446\u0435\u0441\u0441"
     ],
     "name:scn_x_preferred":[
         "Giudizziu"
+    ],
+    "name:slv_x_preferred":[
+        "proces"
+    ],
+    "name:sme_x_preferred":[
+        "riektegeavvan"
     ],
     "name:spa_x_preferred":[
         "Proceso jurisdiccional"
@@ -146,11 +191,17 @@
     "name:srp_x_variant":[
         "\u0441\u0443\u0452\u0435\u045a\u0435"
     ],
+    "name:swa_x_preferred":[
+        "Kesi"
+    ],
     "name:swe_x_preferred":[
         "R\u00e4tteg\u00e5ng"
     ],
     "name:swe_x_variant":[
         "r\u00e4tteg\u00e5ng"
+    ],
+    "name:tgl_x_preferred":[
+        "Paglilitis"
     ],
     "name:tur_x_preferred":[
         "Duru\u015fma"
@@ -160,6 +211,15 @@
     ],
     "name:ukr_x_preferred":[
         "\u041f\u0440\u0430\u0432\u043e\u0441\u0443\u0434\u0434\u044f"
+    ],
+    "name:ukr_x_variant":[
+        "\u0441\u0443\u0434\u043e\u0432\u0438\u0439 \u043f\u0440\u043e\u0446\u0435\u0441"
+    ],
+    "name:vec_x_preferred":[
+        "procedimento zudisi\u00e0rio"
+    ],
+    "name:vie_x_preferred":[
+        "Phi\u00ean t\u00f2a"
     ],
     "name:yue_x_preferred":[
         "\u5be9\u5224"
@@ -210,7 +270,7 @@
         }
     ],
     "wof:id":421191719,
-    "wof:lastmodified":1566651197,
+    "wof:lastmodified":1690867110,
     "wof:name":"Trial",
     "wof:parent_id":85678229,
     "wof:placetype":"locality",

--- a/data/856/321/85/85632185.geojson
+++ b/data/856/321/85/85632185.geojson
@@ -34,6 +34,9 @@
     "name:als_x_preferred":[
         "Sint Maarten"
     ],
+    "name:ami_x_preferred":[
+        "Sint Maarten"
+    ],
     "name:ara_x_preferred":[
         "\u0633\u064a\u0646\u062a \u0645\u0627\u0631\u062a\u0646"
     ],
@@ -154,7 +157,16 @@
     "name:fry_x_variant":[
         "Sint Marten"
     ],
+    "name:fur_x_preferred":[
+        "Saint Marteen"
+    ],
     "name:gag_x_preferred":[
+        "Sint Maarten"
+    ],
+    "name:gcr_x_preferred":[
+        "Sen-Martin"
+    ],
+    "name:gle_x_preferred":[
         "Sint Maarten"
     ],
     "name:glg_x_preferred":[
@@ -190,6 +202,9 @@
     "name:hye_x_preferred":[
         "\u054d\u056b\u0576\u057f \u0544\u0561\u0561\u0580\u057f\u0565\u0576"
     ],
+    "name:ido_x_preferred":[
+        "Sint Maarten"
+    ],
     "name:ina_x_preferred":[
         "Sint Maarten"
     ],
@@ -214,6 +229,9 @@
     "name:kat_x_preferred":[
         "\u10e1\u10d8\u10dc\u10e2-\u10db\u10d0\u10e0\u10e2\u10d4\u10dc\u10d8"
     ],
+    "name:kir_x_preferred":[
+        "\u0421\u0438\u043d\u0442 \u041c\u0430\u0430\u0440\u0442\u0435\u043d"
+    ],
     "name:kor_x_preferred":[
         "\uc2e0\ud2b8\ub9c8\ub974\ud134"
     ],
@@ -222,6 +240,9 @@
     ],
     "name:lad_x_preferred":[
         "Sint Maarten"
+    ],
+    "name:lat_x_preferred":[
+        "Sanctus Martinus"
     ],
     "name:lav_x_preferred":[
         "Sintm\u0101rtena"
@@ -244,6 +265,9 @@
     ],
     "name:mar_x_preferred":[
         "\u0938\u093f\u0902\u091f \u092e\u093e\u0930\u094d\u091f\u0947\u0928"
+    ],
+    "name:mdf_x_preferred":[
+        "\u0421\u0438\u043d\u0442-\u041c\u0430\u0440\u0442\u044d\u043d"
     ],
     "name:mkd_x_preferred":[
         "\u0421\u0432\u0435\u0442\u0438 \u041c\u0430\u0440\u0442\u0438\u043d (\u0425\u043e\u043b\u0430\u043d\u0434\u0438\u0458\u0430)",
@@ -285,11 +309,17 @@
     "name:oci_x_preferred":[
         "Sint Maarten"
     ],
+    "name:oss_x_preferred":[
+        "\u0421\u0438\u043d\u0442-\u041c\u0430\u0440\u0442\u0435\u043d"
+    ],
     "name:pan_x_preferred":[
         "\u0a38\u0a3f\u0a70\u0a1f \u0a2e\u0a3e\u0a30\u0a1f\u0a28"
     ],
     "name:pap_x_preferred":[
         "sint maarten"
+    ],
+    "name:pap_x_variant":[
+        "Sint Maarten"
     ],
     "name:pms_x_preferred":[
         "Sint Maarten"
@@ -317,11 +347,17 @@
     "name:sco_x_preferred":[
         "Sint Maarten"
     ],
+    "name:shn_x_preferred":[
+        "\u101e\u102d\u107c\u103a\u1089\u1019\u1083\u1087\u1010\u102d\u107c\u103a\u1087"
+    ],
     "name:sin_x_preferred":[
         "\u0dc3\u0dd2\u0db1\u0dca\u0da7\u0dca \u0db8\u0dcf\u0dbb\u0dca\u0da7\u0dd9\u0db1\u0dca"
     ],
     "name:slk_x_preferred":[
         "Sint Maarten"
+    ],
+    "name:slv_x_preferred":[
+        "Nizozemski Sveti Martin"
     ],
     "name:spa_x_preferred":[
         "Sint Maarten"
@@ -329,6 +365,9 @@
     "name:spa_x_variant":[
         "Isla de San Mart\u00edn",
         "San Mart\u00edn"
+    ],
+    "name:srd_x_preferred":[
+        "Sint Maarten"
     ],
     "name:srn_x_preferred":[
         "Sint Maarten"
@@ -349,6 +388,9 @@
     "name:tam_x_preferred":[
         "\u0b9a\u0bbf\u0ba9\u0bcd\u0b9f\u0bc1 \u0bae\u0bbe\u0bb0\u0bcd\u0ba4\u0bbf\u0ba9\u0bcd"
     ],
+    "name:tat_x_preferred":[
+        "\u0421\u0438\u043d\u0442-\u041c\u0430\u0440\u0442\u0435\u043d"
+    ],
     "name:tel_x_preferred":[
         "\u0c38\u0c3f\u0c02\u0c1f\u0c4d \u0c2e\u0c3e\u0c30\u0c4d\u0c1f\u0c46\u0c28\u0c4d"
     ],
@@ -368,6 +410,9 @@
         "\u0633\u0646\u0679 \u0645\u0627\u0631\u0679\u0646 (\u0646\u06cc\u062f\u0631\u0644\u06cc\u0646\u0688\u0632)",
         "\u0633\u0646\u0679 \u0645\u0627\u0631\u0679\u0646"
     ],
+    "name:vec_x_preferred":[
+        "Sint Maarten"
+    ],
     "name:vie_x_preferred":[
         "Sint Maarten"
     ],
@@ -376,6 +421,9 @@
     ],
     "name:wuu_x_preferred":[
         "\u8377\u5c5e\u5723\u9a6c\u4e01"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10e1\u10d8\u10dc\u10e2-\u10db\u10d0\u10e0\u10e2\u10d4\u10dc\u10d8"
     ],
     "name:yue_x_preferred":[
         "\u8377\u5c6c\u8056\u99ac\u4e01"
@@ -591,7 +639,7 @@
         "eng",
         "nld"
     ],
-    "wof:lastmodified":1617827483,
+    "wof:lastmodified":1690867109,
     "wof:name":"Sint Maarten",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/890/434/823/890434823.geojson
+++ b/data/890/434/823/890434823.geojson
@@ -24,6 +24,18 @@
     "name:afr_x_preferred":[
         "Philipsburg"
     ],
+    "name:ara_x_preferred":[
+        "\u0641\u064a\u0644\u064a\u0628\u0633\u0628\u0648\u0631\u062c"
+    ],
+    "name:arg_x_preferred":[
+        "Philipsburg"
+    ],
+    "name:ary_x_preferred":[
+        "\u0641\u064a\u0644\u064a\u067e\u0633\u0628\u0648\u0631\u06ad"
+    ],
+    "name:arz_x_preferred":[
+        "\u0641\u064a\u0644\u064a\u0628\u0633\u0628\u0648\u0631\u062c"
+    ],
     "name:ast_x_preferred":[
         "Philipsburg"
     ],
@@ -32,6 +44,9 @@
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0424\u0456\u043b\u0456\u043f\u0441\u0431\u0443\u0440\u0433"
+    ],
+    "name:bel_x_variant":[
+        "\u0424\u0456\u043b\u0456\u043f\u0441\u0431\u0443\u0440\u0433"
     ],
     "name:bos_x_preferred":[
         "Philipsburg"
@@ -46,6 +61,9 @@
         "Philipsburg"
     ],
     "name:ces_x_preferred":[
+        "Philipsburg"
+    ],
+    "name:cym_x_preferred":[
         "Philipsburg"
     ],
     "name:deu_x_preferred":[
@@ -78,6 +96,9 @@
     "name:fra_x_preferred":[
         "Philipsburg"
     ],
+    "name:gle_x_preferred":[
+        "Philipsburg"
+    ],
     "name:glg_x_preferred":[
         "Philipsburg"
     ],
@@ -87,7 +108,13 @@
     "name:hrv_x_preferred":[
         "Philipsburg"
     ],
+    "name:hye_x_preferred":[
+        "\u0556\u056b\u056c\u056b\u057a\u057d\u0562\u0578\u0582\u0580\u0563"
+    ],
     "name:ind_x_preferred":[
+        "Philipsburg"
+    ],
+    "name:isl_x_preferred":[
         "Philipsburg"
     ],
     "name:ita_x_preferred":[
@@ -102,11 +129,20 @@
     "name:kor_x_preferred":[
         "\ud544\ub9bd\uc2a4\ubdd4\ub974\ud750"
     ],
+    "name:lat_x_preferred":[
+        "Philippoburgum"
+    ],
+    "name:lav_x_preferred":[
+        "Filipsburga"
+    ],
     "name:lit_x_preferred":[
         "Filipsburgas"
     ],
     "name:lmo_x_preferred":[
         "Philipsburg"
+    ],
+    "name:mkd_x_preferred":[
+        "\u0424\u0438\u043b\u0438\u043f\u0441\u0431\u0443\u0440\u0433"
     ],
     "name:nan_x_preferred":[
         "Philipsburg"
@@ -126,6 +162,9 @@
     "name:oci_x_preferred":[
         "Philipsburg"
     ],
+    "name:oss_x_preferred":[
+        "\u0424\u0438\u043b\u0438\u043f\u0441\u0431\u0443\u0440\u0433"
+    ],
     "name:pap_x_preferred":[
         "Philipsburg"
     ],
@@ -138,13 +177,22 @@
     "name:por_x_preferred":[
         "Philipsburg"
     ],
+    "name:ron_x_preferred":[
+        "Philipsburg"
+    ],
     "name:rus_x_preferred":[
         "\u0424\u0438\u043b\u0438\u043f\u0441\u0431\u0443\u0440\u0433"
     ],
     "name:sco_x_preferred":[
         "Philipsburg"
     ],
+    "name:slv_x_preferred":[
+        "Philipsburg"
+    ],
     "name:spa_x_preferred":[
+        "Philipsburg"
+    ],
+    "name:srd_x_preferred":[
         "Philipsburg"
     ],
     "name:srp_x_preferred":[
@@ -158,6 +206,9 @@
     ],
     "name:tha_x_preferred":[
         "\u0e1f\u0e35\u0e25\u0e34\u0e1b\u0e2a\u0e4c\u0e1a\u0e37\u0e23\u0e4c\u0e04"
+    ],
+    "name:tha_x_variant":[
+        "\u0e1f\u0e34\u0e25\u0e34\u0e1b\u0e2a\u0e4c\u0e1a\u0e37\u0e23\u0e4c\u0e04"
     ],
     "name:tur_x_preferred":[
         "Philipsburg"
@@ -176,6 +227,9 @@
     ],
     "name:war_x_preferred":[
         "Philipsburg"
+    ],
+    "name:wuu_x_preferred":[
+        "\u83f2\u5229\u666e\u65af\u5821"
     ],
     "name:zho_x_preferred":[
         "\u83f2\u5229\u666e\u65af\u5821"
@@ -221,7 +275,7 @@
         }
     ],
     "wof:id":890434823,
-    "wof:lastmodified":1607390891,
+    "wof:lastmodified":1690867110,
     "wof:name":"Philipsburg",
     "wof:parent_id":85678229,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.