### PR TITLE
sx concordances, placetype local, and more

### DIFF
--- a/data/856/321/85/85632185.geojson
+++ b/data/856/321/85/85632185.geojson
@@ -611,6 +611,7 @@
         "gn:id":7609695,
         "gp:id":56558058,
         "hasc:id":"SX",
+        "iso:code":"SX",
         "m49:code":"534",
         "marc:id":"sn",
         "ne:adm0_a3":"SXM",
@@ -618,6 +619,7 @@
         "qs_pg:id":693867,
         "wd:id":"Q26273"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         85678229
     ],
@@ -643,7 +645,7 @@
         "eng",
         "nld"
     ],
-    "wof:lastmodified":1694639527,
+    "wof:lastmodified":1695881183,
     "wof:name":"Sint Maarten",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/782/29/85678229.geojson
+++ b/data/856/782/29/85678229.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003184,
-    "geom:area_square_m":37431037.791568,
+    "geom:area_square_m":37431037.791561,
     "geom:bbox":"-63.139164,18.00511,-63.013638,18.064115",
     "geom:latitude":18.038975,
     "geom:longitude":-63.062679,
@@ -432,8 +432,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":23425000,
-        "hasc:id":"SX.SM"
+        "hasc:id":"SX.SM",
+        "iso:code_pseudo":"SX"
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:coterminous":[
         85632185
     ],
@@ -441,7 +443,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4191b822d214013dd6e5dfe77bc4faab",
+    "wof:geomhash":"3fcf1120575ccfa40c99814312b3a219",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -458,7 +460,7 @@
         "eng",
         "nld"
     ],
-    "wof:lastmodified":1607980639,
+    "wof:lastmodified":1695884464,
     "wof:name":"Sint Maarten",
     "wof:parent_id":85632185,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.